### PR TITLE
Fix exception thrown when IP header includes port number

### DIFF
--- a/src/Serilog.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Serilog.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -14,7 +14,7 @@ namespace Serilog.Extensions
                 remoteIp = remoteIp.MapToIPv4();
             if (httpContext.Request.Headers.TryGetValue("X-Forwarded-For", out var forwardedIps))
             {
-                var ipString = forwardedIps.First().Split(',')[0].Trim();
+                var ipString = forwardedIps.First().Split(',')[0].Split(':')[0].Trim();
                 try
                 {
                     remoteIp = IPAddress.Parse(ipString);


### PR DESCRIPTION
IPAddress.Parse is unable to handle an IP:PORT combination, so it must be stripped.

Ideally we would also capture the port number in the logs somewhere but I consider that outside the scope of this fix.